### PR TITLE
Add Docker image publishing to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,51 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.9-eclipse-temurin-21-alpine AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn package -DskipTests -B
+
+FROM eclipse-temurin:21-alpine
+WORKDIR /app
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=build /app/target/translate-api-*-jar-with-dependencies.jar app.jar
+RUN chown app:app app.jar
+USER app
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ A Java API to translate texts with various translation services. The following s
 mvn install package
 ```
 
+## Docker
+
+Pre-built images are published to the GitHub Container Registry on every release.
+
+**Pull the image**
+
+```sh
+docker pull ghcr.io/sitepark/translate-api:latest
+```
+
+**Run the container**
+
+```sh
+docker run --rm ghcr.io/sitepark/translate-api:latest translate-json "deepl:XXXXXXXXXX" src/lang de src/lang/de.translated
+```
+
+**Use a specific version**
+
+```sh
+docker pull ghcr.io/sitepark/translate-api:2.3.0
+```
+
 ## How to use
 
 Maven-Dependency


### PR DESCRIPTION
# Add Docker image publishing to GitHub Container Registry

## Summary

- Adds a `Dockerfile` using a multi-stage build: Maven builds the fat jar in the first stage, which is then copied into a minimal `eclipse-temurin:21-alpine` runtime image. The container runs as a non-root user for security.
- Adds `.github/workflows/publish-docker-image.yml` to automatically build and push the image to `ghcr.io` on every release tag (`x.y.z`), including artifact attestation for supply chain security.
- Documents Docker usage in `README.md` with examples for pulling and running the image.