### PR TITLE
feat: protect plain-text placeholders via XML tag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,3 +304,10 @@ TranslatorConfiguration translatorConfiguration = TranslatorConfiguration.builde
 		//...
 		.build();
 ```
+
+Plain-text strings containing placeholders are detected automatically — no explicit `Format` needs to be set. The protection mechanism differs by provider:
+
+- **DeepL**: uses XML tag handling (`tag_handling=xml` + `ignore_tags`). Only strings that actually contain placeholders are sent in XML mode; plain strings without placeholders are unaffected.
+- **LibreTranslate**: uses HTML mode with `translate="no"` span tags, since LibreTranslate does not support XML tag handling.
+
+HTML strings that also contain placeholders continue to use HTML mode on both providers.

--- a/src/main/java/com/sitepark/translate/Format.java
+++ b/src/main/java/com/sitepark/translate/Format.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 public enum Format {
   TEXT,
   HTML,
+  XML,
   AUTO;
 
   @Override

--- a/src/main/java/com/sitepark/translate/provider/deepl/DeeplTranslationProvider.java
+++ b/src/main/java/com/sitepark/translate/provider/deepl/DeeplTranslationProvider.java
@@ -44,9 +44,11 @@ public class DeeplTranslationProvider implements TranslationProvider {
   public TranslationResult translate(TranslationRequest req) {
 
     String[] sourceTextToTranslate = req.getSourceText();
-    if (req.getParameter().getFormat().isPresent()
-        && req.getParameter().getFormat().get() == Format.HTML) {
+    Format format = req.getParameter().getFormat().orElse(null);
+    if (format == Format.HTML) {
       sourceTextToTranslate = this.encodePlacerholder(req.getSourceText());
+    } else if (format == Format.XML) {
+      sourceTextToTranslate = this.encodePlacerholderXml(req.getSourceText());
     }
 
     UnifiedSourceText unifiedSourceText = new UnifiedSourceText(sourceTextToTranslate);
@@ -59,7 +61,10 @@ public class DeeplTranslationProvider implements TranslationProvider {
 
       String[] translated = translationRequest(modifiedReq);
 
-      String[] decodedTranslation = this.decodePlacerholder(translated);
+      String[] decodedTranslation =
+          format == Format.XML
+              ? this.decodePlacerholderXml(translated)
+              : this.decodePlacerholder(translated);
 
       return TranslationResult.builder()
           .request(req)
@@ -88,9 +93,14 @@ public class DeeplTranslationProvider implements TranslationProvider {
     List<String[]> params = new ArrayList<>();
     params.add(new String[] {"source_lang", language.getSource()});
     params.add(new String[] {"target_lang", language.getTarget()});
-    if (req.getParameter().getFormat().isPresent()
-        && req.getParameter().getFormat().get() == Format.HTML) {
-      params.add(new String[] {"tag_handling", Format.HTML.toString().toLowerCase()});
+    if (req.getParameter().getFormat().isPresent()) {
+      Format fmt = req.getParameter().getFormat().get();
+      if (fmt == Format.HTML) {
+        params.add(new String[] {"tag_handling", "html"});
+      } else if (fmt == Format.XML) {
+        params.add(new String[] {"tag_handling", "xml"});
+        params.add(new String[] {"ignore_tags", "x"});
+      }
     }
     for (String text : req.getSourceText()) {
       params.add(new String[] {"text", text});
@@ -162,6 +172,22 @@ public class DeeplTranslationProvider implements TranslationProvider {
     }
 
     return Decoder.decode(q);
+  }
+
+  private String[] encodePlacerholderXml(String... q) {
+    if (!this.translatorConfiguration.isEncodePlaceholder()) {
+      return q;
+    }
+
+    return Encoder.encodeXml(q);
+  }
+
+  private String[] decodePlacerholderXml(String... q) {
+    if (!this.translatorConfiguration.isEncodePlaceholder()) {
+      return q;
+    }
+
+    return Decoder.decodeXml(q);
   }
 
   private int byteCount(String... array) {

--- a/src/main/java/com/sitepark/translate/provider/libretranslate/LibreTranslateTranslationProvider.java
+++ b/src/main/java/com/sitepark/translate/provider/libretranslate/LibreTranslateTranslationProvider.java
@@ -1,6 +1,7 @@
 package com.sitepark.translate.provider.libretranslate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sitepark.translate.Format;
 import com.sitepark.translate.Glossary;
 import com.sitepark.translate.SupportedLanguages;
 import com.sitepark.translate.TranslationConfiguration;
@@ -36,16 +37,24 @@ public class LibreTranslateTranslationProvider implements TranslationProvider {
 
   public TranslationResult translate(TranslationRequest req) {
 
+    Format format = req.getParameter().getFormat().orElse(null);
+    Format effectiveFormat = format == Format.XML ? Format.HTML : format;
+
     String[] encodedSourceText = this.encodePlacerholder(req.getSourceText());
 
     UnifiedSourceText unifiedSourceText = new UnifiedSourceText(encodedSourceText);
+
+    TranslationParameter effectiveParameter =
+        effectiveFormat != format
+            ? req.getParameter().toBuilder().format(effectiveFormat).build()
+            : req.getParameter();
 
     try {
 
       long start = System.currentTimeMillis();
 
       String[] translated =
-          this.translationRequest(req.getParameter(), unifiedSourceText.getSourceText());
+          this.translationRequest(effectiveParameter, unifiedSourceText.getSourceText());
 
       String[] decodedTranslation = this.decodePlacerholder(translated);
 

--- a/src/main/java/com/sitepark/translate/translator/FormatDetector.java
+++ b/src/main/java/com/sitepark/translate/translator/FormatDetector.java
@@ -1,6 +1,7 @@
 package com.sitepark.translate.translator;
 
 import com.sitepark.translate.Format;
+import com.sitepark.translate.translator.entity.Encoder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,18 +17,14 @@ public final class FormatDetector {
   }
 
   public static boolean containsPlaceholder(String text) {
-    return text.indexOf("${") != -1;
+    return Encoder.hasPlaceholder(text);
   }
 
   public static Format detect(String text) {
     if (FormatDetector.containsHtml(text)) {
       return Format.HTML;
-      /*
-       *  HTML must also be used for placeholders since they
-       *  are masked with <span translate="no">.
-       */
     } else if (FormatDetector.containsPlaceholder(text)) {
-      return Format.HTML;
+      return Format.XML;
     } else {
       return Format.TEXT;
     }

--- a/src/main/java/com/sitepark/translate/translator/TranslatableTextListTranslator.java
+++ b/src/main/java/com/sitepark/translate/translator/TranslatableTextListTranslator.java
@@ -34,13 +34,15 @@ public final class TranslatableTextListTranslator extends Translator {
 
     TranslationResultStatistic htmlStatistic = this.translate(Format.HTML, parameter, untranslated);
 
+    TranslationResultStatistic xmlStatistic = this.translate(Format.XML, parameter, untranslated);
+
     TranslationResultStatistic textStatistic = this.translate(Format.TEXT, parameter, untranslated);
 
     if (this.getTranslationCache() != null) {
       this.getTranslationCache().update(translatableTextList);
     }
 
-    return htmlStatistic.add(textStatistic);
+    return htmlStatistic.add(xmlStatistic).add(textStatistic);
   }
 
   private TranslationResultStatistic translate(

--- a/src/main/java/com/sitepark/translate/translator/entity/Decoder.java
+++ b/src/main/java/com/sitepark/translate/translator/entity/Decoder.java
@@ -6,6 +6,11 @@ import java.util.regex.Pattern;
 
 public final class Decoder {
 
+  private static final Pattern HTML_ENTITY_PATTERN =
+      Pattern.compile("(<span data-encoded-entity=\"true\" translate=\"no\">)(.*?)(</span>)");
+
+  private static final Pattern XML_ENTITY_PATTERN = Pattern.compile("<x>(.*?)</x>");
+
   private Decoder() {}
 
   public static String[] decode(String... text) {
@@ -13,9 +18,7 @@ public final class Decoder {
   }
 
   public static String decode(String text) {
-    Pattern pattern =
-        Pattern.compile("(<span data-encoded-entity=\"true\" translate=\"no\">)(.*?)(</span>)");
-    Matcher matcher = pattern.matcher(text);
+    Matcher matcher = HTML_ENTITY_PATTERN.matcher(text);
     int start = 0;
     StringBuilder decoded = new StringBuilder();
     while (matcher.find()) {
@@ -24,5 +27,19 @@ public final class Decoder {
     }
     decoded.append(text.substring(start, text.length()));
     return decoded.toString();
+  }
+
+  public static String[] decodeXml(String... text) {
+    return Arrays.stream(text).map(Decoder::decodeXml).toArray(String[]::new);
+  }
+
+  public static String decodeXml(String text) {
+    Matcher m = XML_ENTITY_PATTERN.matcher(text);
+    StringBuffer sb = new StringBuffer();
+    while (m.find()) {
+      m.appendReplacement(sb, Matcher.quoteReplacement(m.group(1)));
+    }
+    m.appendTail(sb);
+    return sb.toString().replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">");
   }
 }

--- a/src/main/java/com/sitepark/translate/translator/entity/Encoder.java
+++ b/src/main/java/com/sitepark/translate/translator/entity/Encoder.java
@@ -1,10 +1,15 @@
 package com.sitepark.translate.translator.entity;
 
 import java.util.Arrays;
+import java.util.List;
 
 public final class Encoder {
 
   private Encoder() {}
+
+  public static boolean hasPlaceholder(String text) {
+    return new Scanner(text).scanTokens().stream().anyMatch(t -> t.type == TokenType.ENTITY);
+  }
 
   public static String[] encode(String... text) {
     return Arrays.stream(text).map(Encoder::encode).toArray(String[]::new);
@@ -27,5 +32,25 @@ public final class Encoder {
     }
 
     return encoded.toString();
+  }
+
+  public static String[] encodeXml(String... text) {
+    return Arrays.stream(text).map(Encoder::encodeXml).toArray(String[]::new);
+  }
+
+  public static String encodeXml(String text) {
+    List<Token> tokens = new Scanner(text).scanTokens();
+    if (tokens.stream().noneMatch(t -> t.type == TokenType.ENTITY)) {
+      return text;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Token token : tokens) {
+      if (token.type == TokenType.STRING) {
+        sb.append(token.lexeme.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"));
+      } else if (token.type == TokenType.ENTITY) {
+        sb.append("<x>").append(token.lexeme).append("</x>");
+      }
+    }
+    return sb.toString();
   }
 }

--- a/src/test/java/com/sitepark/translate/provider/deepl/DeeplTranslationProviderTest.java
+++ b/src/test/java/com/sitepark/translate/provider/deepl/DeeplTranslationProviderTest.java
@@ -2,6 +2,7 @@ package com.sitepark.translate.provider.deepl;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sitepark.translate.Format;
 import com.sitepark.translate.Glossary;
@@ -71,6 +72,44 @@ class DeeplTranslationProviderTest {
 
     assertArrayEquals(
         new String[] {"Hello", "World"}, translated.getText(), "unexpected translation");
+  }
+
+  @Test
+  void testXmlFormatSendsTagHandlingAndIgnoreTags() throws Exception {
+
+    DeeplTranslationProviderConfiguration providerConfig =
+        DeeplTranslationProviderConfiguration.builder()
+            .url(this.mockWebServer.url("").toString().replaceAll("/$", ""))
+            .authKey("test")
+            .build();
+
+    TranslationConfiguration config =
+        TranslationConfiguration.builder()
+            .encodePlaceholder(true)
+            .translationProviderConfiguration(providerConfig)
+            .build();
+
+    DeeplTranslationProvider xmlProvider = new DeeplTranslationProvider(config);
+
+    TranslationLanguage language = TranslationLanguage.builder().source("de").target("en").build();
+
+    TranslationRequest req =
+        TranslationRequest.builder()
+            .parameter(
+                TranslationParameter.builder()
+                    .format(Format.XML)
+                    .language(language)
+                    .providerType(SupportedProvider.DEEPL)
+                    .build())
+            .sourceText("Hallo {name}", "Welt {value}")
+            .build();
+
+    xmlProvider.translate(req);
+
+    RecordedRequest recorded = this.mockWebServer.takeRequest();
+    String body = recorded.getBody().readUtf8();
+    assertTrue(body.contains("tag_handling=xml"), "expected tag_handling=xml in body: " + body);
+    assertTrue(body.contains("ignore_tags=x"), "expected ignore_tags=x in body: " + body);
   }
 
   @Test

--- a/src/test/java/com/sitepark/translate/provider/libretranslate/LibreTranslateTranslationProviderTest.java
+++ b/src/test/java/com/sitepark/translate/provider/libretranslate/LibreTranslateTranslationProviderTest.java
@@ -1,6 +1,7 @@
 package com.sitepark.translate.provider.libretranslate;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.sitepark.translate.Format;
@@ -44,6 +45,35 @@ class LibreTranslateTranslationProviderTest {
         new String[] {"Hello", "World"}, translated.getText(), "unexpected translation");
   }
 
+  @Test
+  void testXmlFormatFallsBackToHtml() {
+
+    TranslationConfiguration config = Mockito.mock(TranslationConfiguration.class);
+    when(config.isEncodePlaceholder()).thenReturn(true);
+
+    CapturingLibreTranslateProvider provider = new CapturingLibreTranslateProvider(config);
+
+    TranslationLanguage language = TranslationLanguage.builder().source("de").target("en").build();
+
+    TranslationRequest req =
+        TranslationRequest.builder()
+            .parameter(
+                TranslationParameter.builder()
+                    .format(Format.XML)
+                    .language(language)
+                    .providerType(SupportedProvider.LIBRE_TRANSLATE)
+                    .build())
+            .sourceText("Hallo {name}")
+            .build();
+
+    provider.translate(req);
+
+    assertEquals(
+        Format.HTML,
+        provider.capturedFormat,
+        "XML format should fall back to HTML for LibreTranslate");
+  }
+
   private static final class HelloWorldLibreTranslateTranslationProvider
       extends LibreTranslateTranslationProvider {
 
@@ -56,6 +86,23 @@ class LibreTranslateTranslationProviderTest {
     protected String[] translationRequest(TranslationParameter parameter, String... source)
         throws IOException, InterruptedException {
       return new String[] {"Hello", "World"};
+    }
+  }
+
+  private static final class CapturingLibreTranslateProvider
+      extends LibreTranslateTranslationProvider {
+
+    Format capturedFormat;
+
+    public CapturingLibreTranslateProvider(TranslationConfiguration translatorConfiguration) {
+      super(translatorConfiguration);
+    }
+
+    @Override
+    protected String[] translationRequest(TranslationParameter parameter, String... source)
+        throws IOException, InterruptedException {
+      this.capturedFormat = parameter.getFormat().orElse(null);
+      return source;
     }
   }
 }

--- a/src/test/java/com/sitepark/translate/translator/FormatDetectorTest.java
+++ b/src/test/java/com/sitepark/translate/translator/FormatDetectorTest.java
@@ -1,8 +1,10 @@
 package com.sitepark.translate.translator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sitepark.translate.Format;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -53,8 +55,35 @@ class FormatDetectorTest {
   }
 
   @Test
-  void testContainsPlaceholder() {
+  void testContainsPlaceholderDollarBrace() {
     assertTrue(
         FormatDetector.containsPlaceholder("Good morning ${name}"), "should find placeholder");
+  }
+
+  @Test
+  void testContainsPlaceholderBrace() {
+    assertTrue(
+        FormatDetector.containsPlaceholder("Good morning {name}"), "should find placeholder");
+  }
+
+  @Test
+  void testDetectPlainTextWithDollarBracePlaceholder() {
+    assertEquals(Format.XML, FormatDetector.detect("Good morning ${name}"), "expected XML");
+  }
+
+  @Test
+  void testDetectPlainTextWithBracePlaceholder() {
+    assertEquals(Format.XML, FormatDetector.detect("Hello {name}!"), "expected XML");
+  }
+
+  @Test
+  void testDetectHtmlWithPlaceholder() {
+    assertEquals(
+        Format.HTML, FormatDetector.detect("<b>Hello</b> {name}"), "HTML takes priority over XML");
+  }
+
+  @Test
+  void testDetectPlainText() {
+    assertEquals(Format.TEXT, FormatDetector.detect("Hello World"), "expected TEXT");
   }
 }

--- a/src/test/java/com/sitepark/translate/translator/TranslatableTextTest.java
+++ b/src/test/java/com/sitepark/translate/translator/TranslatableTextTest.java
@@ -22,7 +22,7 @@ class TranslatableTextTest {
   @Test
   void testAutoDetectPlaceholderConstructor() {
     TranslatableText text = new TranslatableText("text with placeholder ${name}");
-    assertEquals(Format.HTML, text.getFormat(), "format should be html");
+    assertEquals(Format.XML, text.getFormat(), "format should be xml");
   }
 
   @Test

--- a/src/test/java/com/sitepark/translate/translator/entity/DecoderTest.java
+++ b/src/test/java/com/sitepark/translate/translator/entity/DecoderTest.java
@@ -13,4 +13,19 @@ class DecoderTest {
             "Ein Text mit <span data-encoded-entity=\"true\" translate=\"no\">${text}</span>.");
     assertEquals("Ein Text mit ${text}.", s, "Unexpected text");
   }
+
+  @Test
+  void testDecodeXmlStripsWrapper() {
+    assertEquals("Hello {name}!", Decoder.decodeXml("Hello <x>{name}</x>!"), "Unexpected decode");
+  }
+
+  @Test
+  void testDecodeXmlUnescapesEntities() {
+    assertEquals("A & B {val}", Decoder.decodeXml("A &amp; B <x>{val}</x>"), "Unexpected unescape");
+  }
+
+  @Test
+  void testDecodeXmlNoWrappersIsUnchanged() {
+    assertEquals("Hello World", Decoder.decodeXml("Hello World"), "Should be unchanged");
+  }
 }

--- a/src/test/java/com/sitepark/translate/translator/entity/EncoderTest.java
+++ b/src/test/java/com/sitepark/translate/translator/entity/EncoderTest.java
@@ -14,4 +14,29 @@ class EncoderTest {
         s,
         "Unexpected encoding");
   }
+
+  @Test
+  void testEncodeXmlWithPlaceholder() {
+    assertEquals(
+        "Hello <x>{name}</x>!", Encoder.encodeXml("Hello {name}!"), "Unexpected XML encoding");
+  }
+
+  @Test
+  void testEncodeXmlWithDollarBracePlaceholder() {
+    assertEquals(
+        "Hello <x>${name}</x>!", Encoder.encodeXml("Hello ${name}!"), "Unexpected XML encoding");
+  }
+
+  @Test
+  void testEncodeXmlWithoutPlaceholderIsUnchanged() {
+    assertEquals("Hello World", Encoder.encodeXml("Hello World"), "Plain text should be unchanged");
+  }
+
+  @Test
+  void testEncodeXmlEscapesSpecialChars() {
+    assertEquals(
+        "A &amp; B &lt;x&gt; <x>{val}</x>",
+        Encoder.encodeXml("A & B <x> {val}"),
+        "Unexpected XML escaping");
+  }
 }


### PR DESCRIPTION
## Problem

Plain-text strings containing `{name}`-style placeholders were not protected during translation. `FormatDetector` only recognised the `${...}` form, and even then forced `Format.HTML` as a workaround — wrapping placeholders in `<span translate="no">` tags, which requires the translation API to be in HTML mode. Strings using the `{...}` form (Symfony, ICU, etc.) were classified as `Format.TEXT` and sent to the provider without any protection, allowing the translator to mangle or drop placeholder tokens.

## Solution

Introduces `Format.XML` for plain-text strings that contain placeholders. Strings are auto-detected using the existing `Scanner` tokeniser, so no changes are required at the call site beyond `encodePlaceholder(true)`.

- **DeepL**: sends `tag_handling=xml` + `ignore_tags=x`. Only strings that actually contain placeholders are affected; pure plain-text strings continue to use `Format.TEXT`.
- **LibreTranslate**: falls back to the existing HTML span encoding, since LibreTranslate has no XML tag handling support.
- HTML strings that also contain placeholders continue to use HTML mode on both providers (unchanged behaviour).

## Changes

- `Format` — new `XML` enum value
- `Encoder` — `hasPlaceholder()` helper; `encodeXml()` wraps entities in
  `<x>…</x>` and XML-escapes surrounding text; no-op when no placeholder
- `Decoder` — `decodeXml()` strips `<x>` wrappers and XML-unescapes
- `FormatDetector` — uses `Encoder.hasPlaceholder()` to detect both
  `{…}` and `${…}`; returns `Format.XML` instead of `Format.HTML` for
  placeholder-only strings
- `TranslatableTextListTranslator` — added `Format.XML` translation batch
- `DeeplTranslationProvider` — handles `Format.XML` encode/decode path
- `LibreTranslateTranslationProvider` — maps `Format.XML` → `Format.HTML
- README — documents the per-provider protection mechanism