### PR TITLE
fix: write translated json/yaml files to configured output dir

### DIFF
--- a/src/main/java/com/sitepark/translate/cli/TranslateJsonFile.java
+++ b/src/main/java/com/sitepark/translate/cli/TranslateJsonFile.java
@@ -58,6 +58,7 @@ public class TranslateJsonFile {
     String url = arguments[0];
     Path dir = Paths.get(arguments[1]).toAbsolutePath();
     String sourceLang = arguments[2];
+    Path output = arguments.length > 3 ? Paths.get(arguments[3]).toAbsolutePath() : dir;
     if (!Files.exists(dir)) {
       throw new IllegalArgumentException("dir " + dir + " not exitst");
     }
@@ -78,7 +79,7 @@ public class TranslateJsonFile {
     this.jsonFileTranslator =
         JsonFileTranslator.builder()
             .dir(dir)
-            .output(dir)
+            .output(output)
             .sourceLang(sourceLang)
             .translatorConfiguration(translatorConfiguration)
             .logger(new ConsoleLogger(true))
@@ -143,13 +144,16 @@ public class TranslateJsonFile {
 
   private void usage() {
     System.out.println(
-        "translate translate-json <libre-translate-url> <dir> <source-lang> <output-dir>");
+        "translate translate-json-file <url> <dir> <source-lang> [output-dir] "
+            + "[target-language]...");
     System.out.println("");
     System.out.println(
         "<url>                   URL to translation server: "
             + "<provider-scheme>:http[s]://host/[?params]");
     System.out.println("<dir>                   directory in which the json files are located");
     System.out.println("<source-lang>           Language to be translated.");
+    System.out.println(
+        "[output-dir]            directory to write translated files to (default: <dir>)");
     System.out.println("");
     System.out.println("Supported provider-scheme:");
     for (String provider : SupportedProvider.scheme()) {

--- a/src/main/java/com/sitepark/translate/cli/TranslateYamlFile.java
+++ b/src/main/java/com/sitepark/translate/cli/TranslateYamlFile.java
@@ -58,6 +58,7 @@ public class TranslateYamlFile {
     String url = arguments[0];
     Path dir = Paths.get(arguments[1]).toAbsolutePath();
     String sourceLang = arguments[2];
+    Path output = arguments.length > 3 ? Paths.get(arguments[3]).toAbsolutePath() : dir;
     if (!Files.exists(dir)) {
       throw new IllegalArgumentException("dir " + dir + " not exitst");
     }
@@ -78,7 +79,7 @@ public class TranslateYamlFile {
     this.yamlFileTranslator =
         YamlFileTranslator.builder()
             .dir(dir)
-            .output(dir)
+            .output(output)
             .sourceLang(sourceLang)
             .translatorConfiguration(translatorConfiguration)
             .logger(new ConsoleLogger(true))
@@ -142,13 +143,17 @@ public class TranslateYamlFile {
   }
 
   private void usage() {
-    System.out.println("translate translate-yaml-file <url> <dir> <source-lang>");
+    System.out.println(
+        "translate translate-yaml-file <url> <dir> <source-lang> [output-dir] "
+            + "[target-language]...");
     System.out.println("");
     System.out.println(
         "<url>                   URL to translation server: "
             + "<provider-scheme>:http[s]://host/[?params]");
     System.out.println("<dir>                   directory in which the yaml files are located");
     System.out.println("<source-lang>           Language to be translated.");
+    System.out.println(
+        "[output-dir]            directory to write translated files to (default: <dir>)");
     System.out.println("");
     System.out.println("Supported provider-scheme:");
     for (String provider : SupportedProvider.scheme()) {

--- a/src/main/java/com/sitepark/translate/translator/JsonFileTranslator.java
+++ b/src/main/java/com/sitepark/translate/translator/JsonFileTranslator.java
@@ -107,13 +107,8 @@ public final class JsonFileTranslator extends Translator {
     ObjectMapper mapper = new ObjectMapper();
 
     for (JsonFile jsonFile : this.jsonFiles) {
-      Path parent = jsonFile.sourceFile.getParent();
-      if (parent == null) {
-        parent = this.dir;
-      }
-      if (parent == null) {
-        throw new IllegalStateException("parent is null");
-      }
+      Path relativeParent = jsonFile.sourceFile.getParent();
+      Path parent = relativeParent == null ? this.output : this.output.resolve(relativeParent);
 
       Path filenamePath = jsonFile.sourceFile.getFileName();
       if (filenamePath == null) {

--- a/src/main/java/com/sitepark/translate/translator/YamlFileTranslator.java
+++ b/src/main/java/com/sitepark/translate/translator/YamlFileTranslator.java
@@ -117,13 +117,8 @@ public final class YamlFileTranslator extends Translator {
     YAMLMapper mapper = new YAMLMapper();
 
     for (YamlFile yamlFile : this.yamlFiles) {
-      Path parent = yamlFile.sourceFile.getParent();
-      if (parent == null) {
-        parent = this.dir;
-      }
-      if (parent == null) {
-        throw new IllegalStateException("parent is null");
-      }
+      Path relativeParent = yamlFile.sourceFile.getParent();
+      Path parent = relativeParent == null ? this.output : this.output.resolve(relativeParent);
 
       Path filenamePath = yamlFile.sourceFile.getFileName();
       if (filenamePath == null) {

--- a/src/test/java/com/sitepark/translate/cli/TranslateJsonFileTest.java
+++ b/src/test/java/com/sitepark/translate/cli/TranslateJsonFileTest.java
@@ -21,4 +21,15 @@ class TranslateJsonFileTest {
         "libretranslate:https://dummy?apiKey=abc", "src/test/resources/translate-json", "de");
     assertNotNull(translateJsonFile.getTranslator(), "translator expected");
   }
+
+  @Test
+  void testParseArgumentsWithOutputDir() {
+    TranslateJsonFile translateJsonFile = new TranslateJsonFile();
+    translateJsonFile.parseArguments(
+        "deepl:https://dummy?authKey=abc",
+        "src/test/resources/translate-json",
+        "de",
+        "target/test/translate-json-generated");
+    assertNotNull(translateJsonFile.getTranslator(), "translator expected");
+  }
 }

--- a/src/test/java/com/sitepark/translate/cli/TranslateYamlFileTest.java
+++ b/src/test/java/com/sitepark/translate/cli/TranslateYamlFileTest.java
@@ -32,13 +32,24 @@ class TranslateYamlFileTest {
   }
 
   @Test
+  void testParseArgumentsWithOutputDir() {
+    TranslateYamlFile translateYamlFile = new TranslateYamlFile();
+    translateYamlFile.parseArguments(
+        "deepl:https://dummy?authKey=abc",
+        "src/test/resources/translate-yaml",
+        "de",
+        "target/test/translate-yaml-generated");
+    assertNotNull(translateYamlFile.getTranslator(), "translator expected");
+  }
+
+  @Test
   void testParseArgumentsWithTargetLanguages() {
     TranslateYamlFile translateYamlFile = new TranslateYamlFile();
     translateYamlFile.parseArguments(
         "deepl:https://dummy?authKey=abc",
         "src/test/resources/translate-yaml",
         "de",
-        "unused",
+        "target/test/translate-yaml-target-langs",
         "en",
         "fr");
     assertNotNull(translateYamlFile.getTranslator(), "translator expected");

--- a/src/test/java/com/sitepark/translate/translator/JsonFileTranslatorTest.java
+++ b/src/test/java/com/sitepark/translate/translator/JsonFileTranslatorTest.java
@@ -1,6 +1,7 @@
 package com.sitepark.translate.translator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -87,6 +88,73 @@ class JsonFileTranslatorTest {
         "{\n" + "  \"text\" : \"Hello\"\n" + "}",
         Files.readString(resultA, StandardCharsets.UTF_8),
         "wrong content in en/a.json");
+  }
+
+  @Test
+  @SuppressWarnings({"PMD.UseConcurrentHashMap", "PMD.UnitTestContainsTooManyAsserts"})
+  void testWithSeparateOutputDirectory() throws Exception {
+
+    SupportedLanguages supportedLanguages =
+        SupportedLanguages.builder()
+            .language(Language.builder().code("de").name("deutsch").targets("en"))
+            .build();
+
+    Map<String, String> dictionary = new HashMap<>();
+    dictionary.put("Hallo", "Hello");
+    dictionary.put("Welt", "World");
+
+    TranslationProvider transporter = mock(TranslationProvider.class);
+    when(transporter.translate(any(TranslationRequest.class)))
+        .thenAnswer(
+            invocationOnMock -> {
+              TranslationRequest req = (TranslationRequest) invocationOnMock.getArguments()[0];
+              String[] sourceText = req.getSourceText();
+              String[] translations = new String[sourceText.length];
+              for (int i = 0; i < translations.length; i++) {
+                translations[i] = dictionary.get(sourceText[i]);
+              }
+
+              return TranslationResult.builder()
+                  .request(req)
+                  .text(translations)
+                  .statistic(TranslationResultStatistic.EMPTY)
+                  .build();
+            });
+    when(transporter.getSupportedLanguages()).thenReturn(supportedLanguages);
+
+    TranslationProviderFactory transporterFactory = mock(TranslationProviderFactory.class);
+    when(transporterFactory.create(any())).thenReturn(transporter);
+
+    TranslationConfiguration translatorConfiguration =
+        TranslationConfiguration.builder().translationProviderFactory(transporterFactory).build();
+
+    Path resources = Paths.get("src/test/resources/JsonFileTranslator");
+    Path testdir = Paths.get("target/test/JsonFileTranslatorSeparateOutput/src");
+    Path outputdir = Paths.get("target/test/JsonFileTranslatorSeparateOutput/generated");
+
+    this.clean(testdir.getParent());
+    this.copyFiles(resources, testdir);
+
+    JsonFileTranslator jsonFileTranslator =
+        JsonFileTranslator.builder()
+            .dir(testdir)
+            .output(outputdir)
+            .sourceLang("de")
+            .targetLangList("en")
+            .translatorConfiguration(translatorConfiguration)
+            .build();
+
+    jsonFileTranslator.translate(SupportedProvider.LIBRE_TRANSLATE);
+
+    Path resultA = outputdir.resolve("a.en.json");
+    assertEquals(
+        "{\n" + "  \"text\" : \"Hello\"\n" + "}",
+        Files.readString(resultA, StandardCharsets.UTF_8),
+        "wrong content in generated/a.en.json");
+
+    assertFalse(
+        Files.exists(testdir.resolve("a.en.json")),
+        "translated file must not be written into the source directory");
   }
 
   private void clean(Path dir) throws IOException {

--- a/src/test/java/com/sitepark/translate/translator/YamlFileTranslatorTest.java
+++ b/src/test/java/com/sitepark/translate/translator/YamlFileTranslatorTest.java
@@ -1,6 +1,7 @@
 package com.sitepark.translate.translator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -265,6 +266,49 @@ class YamlFileTranslatorTest {
     YAMLMapper mapper = new YAMLMapper();
     String result = mapper.readTree(testdir.resolve("a.en.yaml").toFile()).get("text").asText();
     assertEquals("Hello", result, "translation should still succeed despite cache error");
+  }
+
+  @Test
+  @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+  void testWithSeparateOutputDirectory() throws Exception {
+
+    SupportedLanguages supportedLanguages =
+        SupportedLanguages.builder()
+            .language(Language.builder().code("de").name("deutsch").targets("en"))
+            .build();
+
+    Map<String, String> dictionary = new HashMap<>();
+    dictionary.put("Hallo", "Hello");
+
+    TranslationConfiguration translatorConfiguration =
+        this.createTranslatorConfiguration(supportedLanguages, dictionary);
+
+    Path resources = Paths.get("src/test/resources/YamlFileTranslator");
+    Path testdir = Paths.get("target/test/YamlFileTranslatorSeparateOutput/src");
+    Path outputdir = Paths.get("target/test/YamlFileTranslatorSeparateOutput/generated");
+
+    this.clean(testdir.getParent());
+    this.copyFiles(resources, testdir);
+
+    YamlFileTranslator yamlFileTranslator =
+        YamlFileTranslator.builder()
+            .dir(testdir)
+            .output(outputdir)
+            .sourceLang("de")
+            .targetLangList("en")
+            .translatorConfiguration(translatorConfiguration)
+            .build();
+
+    yamlFileTranslator.translate(SupportedProvider.LIBRE_TRANSLATE);
+
+    Path resultA = outputdir.resolve("a.en.yaml");
+    YAMLMapper mapper = new YAMLMapper();
+    String translated = mapper.readTree(resultA.toFile()).get("text").asText();
+    assertEquals("Hello", translated, "wrong translation in a.en.yaml");
+
+    assertFalse(
+        Files.exists(testdir.resolve("a.en.yaml")),
+        "translated file must not be written into the source directory");
   }
 
   private TranslationConfiguration createTranslatorConfiguration(


### PR DESCRIPTION
## Summary

`YamlFileTranslator` and `JsonFileTranslator` accepted an `output` path, but only ever used it for the translation cache — translated files were always written back next to the source, ignoring `output` entirely.

- `YamlFileTranslator.write()` / `JsonFileTranslator.write()` now resolve translated files against `output` (joined with the file's path relative to `dir`), instead of always writing next to the source.
- `TranslateYamlFile` / `TranslateJsonFile` CLI commands now accept an optional 4th `[output-dir]` argument (defaults to `<dir>` if omitted, so existing 3-arg invocations are unaffected).
- Fixes nested-subdirectory sources as a side effect: previously these resolved to a path relative to the JVM's working directory (effectively undefined), now they resolve deterministically under `output`/`dir`.

Example, translating a suffix-style YAML tree into a separate output directory:

```bash
translate translate-yaml-file deepl:https://api.deepl.com/?authKey=XXX /src/translations de /src/translation.generated
```
Example result:
- `sitekit-php/src/`
  - `translations/`
    - `sitekit+intl-icu.de.yaml` (existed beforehand)
  - `translations.generated/`
    - `sitekit+intl-icu.af.yaml` (generated)
    - `sitekit+intl-icu.an.yaml`
    - `sitekit+intl-icu.ar.yaml`
    - ...
    
This is exactly what I need for the new symfony translation files. 