### PR TITLE
feat: protect ICU MessageFormat structure via icu4j-aware encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>icu4j</artifactId>
+			<version>76.1</version>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>

--- a/src/main/java/com/sitepark/translate/translator/FormatDetector.java
+++ b/src/main/java/com/sitepark/translate/translator/FormatDetector.java
@@ -2,6 +2,7 @@ package com.sitepark.translate.translator;
 
 import com.sitepark.translate.Format;
 import com.sitepark.translate.translator.entity.Encoder;
+import com.sitepark.translate.translator.entity.IcuMessageEncoder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,7 +18,7 @@ public final class FormatDetector {
   }
 
   public static boolean containsPlaceholder(String text) {
-    return Encoder.hasPlaceholder(text);
+    return Encoder.hasPlaceholder(text) || IcuMessageEncoder.isIcu(text);
   }
 
   public static Format detect(String text) {

--- a/src/main/java/com/sitepark/translate/translator/entity/Decoder.java
+++ b/src/main/java/com/sitepark/translate/translator/entity/Decoder.java
@@ -6,10 +6,13 @@ import java.util.regex.Pattern;
 
 public final class Decoder {
 
+  // DOTALL so a placeholder that spans newlines (e.g. a multi-line ICU MessageFormat string from a
+  // folded YAML scalar) is still matched and unwrapped.
   private static final Pattern HTML_ENTITY_PATTERN =
-      Pattern.compile("(<span data-encoded-entity=\"true\" translate=\"no\">)(.*?)(</span>)");
+      Pattern.compile(
+          "(<span data-encoded-entity=\"true\" translate=\"no\">)(.*?)(</span>)", Pattern.DOTALL);
 
-  private static final Pattern XML_ENTITY_PATTERN = Pattern.compile("<x>(.*?)</x>");
+  private static final Pattern XML_ENTITY_PATTERN = Pattern.compile("<x>(.*?)</x>", Pattern.DOTALL);
 
   private Decoder() {}
 

--- a/src/main/java/com/sitepark/translate/translator/entity/Encoder.java
+++ b/src/main/java/com/sitepark/translate/translator/entity/Encoder.java
@@ -39,6 +39,9 @@ public final class Encoder {
   }
 
   public static String encodeXml(String text) {
+    if (!text.contains("${") && IcuMessageEncoder.isIcu(text)) {
+      return IcuMessageEncoder.encodeXml(text);
+    }
     List<Token> tokens = new Scanner(text).scanTokens();
     if (tokens.stream().noneMatch(t -> t.type == TokenType.ENTITY)) {
       return text;

--- a/src/main/java/com/sitepark/translate/translator/entity/IcuMessageEncoder.java
+++ b/src/main/java/com/sitepark/translate/translator/entity/IcuMessageEncoder.java
@@ -1,0 +1,150 @@
+package com.sitepark.translate.translator.entity;
+
+import com.ibm.icu.text.MessagePattern;
+import com.ibm.icu.text.MessagePattern.Part;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Placeholder protection for ICU MessageFormat strings.
+ *
+ * <p>The hand-rolled {@link Scanner} only recognizes {@code {...}} as an opaque placeholder when it
+ * contains a bare identifier (e.g. {@code {name}}). It mishandles real ICU MessageFormat syntax
+ * such as {@code {value, number, ::.#}} (typed argument) or {@code {count, plural, one {Kategorie}
+ * other {Kategorien}}} (nested translatable submessages). This encoder uses ICU4J's {@link
+ * MessagePattern} to parse the message, then protects every structural part (argument names,
+ * {@code plural}/{@code select} keywords, selectors, braces, {@code #}) by wrapping it in {@code
+ * <x>...</x>} tags while leaving only the human-language literal text translatable.
+ *
+ * <p>The output uses the same {@code <x>} wrapper and XML escaping as {@link Encoder#encodeXml} so
+ * it is decoded by the existing {@link Decoder#decodeXml} and sent to DeepL with {@code
+ * tag_handling=xml} / {@code ignore_tags=x}.
+ */
+public final class IcuMessageEncoder {
+
+  private IcuMessageEncoder() {}
+
+  /**
+   * Returns {@code true} if the text parses as an ICU MessageFormat pattern that contains at least
+   * one argument. Plain text without arguments (e.g. {@code "Hello World"}) returns {@code false}
+   * so it stays on the legacy path.
+   */
+  public static boolean isIcu(String text) {
+    MessagePattern pattern = parse(text);
+    if (pattern == null) {
+      return false;
+    }
+    int count = pattern.countParts();
+    for (int i = 0; i < count; i++) {
+      if (pattern.getPart(i).getType() == Part.Type.ARG_START) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Wraps all ICU structure in {@code <x>...</x>} and XML-escapes the remaining literal text.
+   * Callers must ensure {@link #isIcu(String)} is {@code true}; otherwise the text is returned
+   * unchanged.
+   */
+  public static String encodeXml(String text) {
+    MessagePattern pattern = parse(text);
+    if (pattern == null) {
+      return text;
+    }
+
+    List<int[]> literals = new ArrayList<>();
+    collectMessageLiterals(pattern, 0, literals);
+
+    StringBuilder out = new StringBuilder(text.length() + 16);
+    int pos = 0;
+    for (int[] range : literals) {
+      if (range[0] > pos) {
+        out.append("<x>").append(text, pos, range[0]).append("</x>");
+      }
+      appendEscaped(out, text, range[0], range[1]);
+      pos = range[1];
+    }
+    if (pos < text.length()) {
+      out.append("<x>").append(text, pos, text.length()).append("</x>");
+    }
+    return out.toString();
+  }
+
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  private static MessagePattern parse(String text) {
+    try {
+      return new MessagePattern(text);
+    } catch (RuntimeException e) {
+      // Not a valid ICU MessageFormat pattern (e.g. unbalanced braces).
+      return null;
+    }
+  }
+
+  /**
+   * Collects the character ranges of translatable literal text within the message starting at
+   * {@code msgStart}. Mirrors ICU's own {@code MessageFormat} literal-text extraction (the text
+   * between structural parts), and additionally recurses into every nested submessage of an
+   * argument so that {@code plural}/{@code select} branch texts are captured too.
+   */
+  private static void collectMessageLiterals(
+      MessagePattern pattern, int msgStart, List<int[]> literals) {
+    int prevIndex = pattern.getPart(msgStart).getLimit();
+    int i = msgStart + 1;
+    while (true) {
+      Part part = pattern.getPart(i);
+      Part.Type type = part.getType();
+      int index = part.getIndex();
+      if (index > prevIndex) {
+        literals.add(new int[] {prevIndex, index});
+      }
+      if (type == Part.Type.MSG_LIMIT) {
+        return;
+      }
+      if (type == Part.Type.ARG_START) {
+        int argLimit = pattern.getLimitPartIndex(i);
+        collectSubmessageLiterals(pattern, i, argLimit, literals);
+        prevIndex = pattern.getPart(argLimit).getLimit();
+        i = argLimit + 1;
+      } else {
+        // SKIP_SYNTAX (apostrophe quoting) and REPLACE_NUMBER (#) are structure, not literal text.
+        prevIndex = part.getLimit();
+        i++;
+      }
+    }
+  }
+
+  /** Recurses into every submessage (plural/select branch) nested inside a single argument. */
+  private static void collectSubmessageLiterals(
+      MessagePattern pattern, int argStart, int argLimit, List<int[]> literals) {
+    int j = argStart + 1;
+    while (j < argLimit) {
+      if (pattern.getPart(j).getType() == Part.Type.MSG_START) {
+        collectMessageLiterals(pattern, j, literals);
+        j = pattern.getLimitPartIndex(j) + 1;
+      } else {
+        j++;
+      }
+    }
+  }
+
+  private static void appendEscaped(StringBuilder out, String text, int start, int end) {
+    for (int i = start; i < end; i++) {
+      char c = text.charAt(i);
+      switch (c) {
+        case '&':
+          out.append("&amp;");
+          break;
+        case '<':
+          out.append("&lt;");
+          break;
+        case '>':
+          out.append("&gt;");
+          break;
+        default:
+          out.append(c);
+      }
+    }
+  }
+}

--- a/src/test/java/com/sitepark/translate/translator/FormatDetectorTest.java
+++ b/src/test/java/com/sitepark/translate/translator/FormatDetectorTest.java
@@ -86,4 +86,25 @@ class FormatDetectorTest {
   void testDetectPlainText() {
     assertEquals(Format.TEXT, FormatDetector.detect("Hello World"), "expected TEXT");
   }
+
+  @Test
+  void testDetectIcuTypedArgument() {
+    assertEquals(
+        Format.XML,
+        FormatDetector.detect("{value, number, ::.#} kB"),
+        "ICU typed argument should be detected as XML");
+  }
+
+  @Test
+  void testDetectIcuPlural() {
+    assertEquals(
+        Format.XML,
+        FormatDetector.detect("{count, plural, one {Kategorie} other {Kategorien}}"),
+        "ICU plural should be detected as XML");
+  }
+
+  @Test
+  void testDetectDatePatternIsPlainText() {
+    assertEquals(Format.TEXT, FormatDetector.detect("dd.MM.yyyy"), "expected TEXT");
+  }
 }

--- a/src/test/java/com/sitepark/translate/translator/entity/DecoderTest.java
+++ b/src/test/java/com/sitepark/translate/translator/entity/DecoderTest.java
@@ -28,4 +28,16 @@ class DecoderTest {
   void testDecodeXmlNoWrappersIsUnchanged() {
     assertEquals("Hello World", Decoder.decodeXml("Hello World"), "Should be unchanged");
   }
+
+  @Test
+  void testDecodeXmlStripsWrapperSpanningNewlines() {
+    assertEquals(
+        "{count, plural,\n    one   {Category}\n    other {Categories}\n    }",
+        Decoder.decodeXml(
+            "<x>{count, plural,\n"
+                + "    one   {</x>Category<x>}\n"
+                + "    other {</x>Categories<x>}\n"
+                + "    }</x>"),
+        "multi-line <x> blocks must be stripped");
+  }
 }

--- a/src/test/java/com/sitepark/translate/translator/entity/EncoderTest.java
+++ b/src/test/java/com/sitepark/translate/translator/entity/EncoderTest.java
@@ -39,4 +39,20 @@ class EncoderTest {
         Encoder.encodeXml("A & B <x> {val}"),
         "Unexpected XML escaping");
   }
+
+  @Test
+  void testEncodeXmlDelegatesToIcuForPlural() {
+    assertEquals(
+        "<x>{count, plural, one {</x>Kategorie<x>} other {</x>Kategorien<x>}}</x>",
+        Encoder.encodeXml("{count, plural, one {Kategorie} other {Kategorien}}"),
+        "ICU plural should be encoded via IcuMessageEncoder");
+  }
+
+  @Test
+  void testEncodeXmlDelegatesToIcuForTypedArgument() {
+    assertEquals(
+        "<x>{value, number, ::.#}</x> kB",
+        Encoder.encodeXml("{value, number, ::.#} kB"),
+        "ICU typed argument should be encoded via IcuMessageEncoder");
+  }
 }

--- a/src/test/java/com/sitepark/translate/translator/entity/IcuMessageEncoderTest.java
+++ b/src/test/java/com/sitepark/translate/translator/entity/IcuMessageEncoderTest.java
@@ -1,0 +1,193 @@
+package com.sitepark.translate.translator.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class IcuMessageEncoderTest {
+
+  private static final String PLURAL_HASH = "{value_int, plural, one {# Byte} other {# Bytes}}";
+  private static final String PLURAL_TEXT = "{count, plural, one {Kategorie} other {Kategorien}}";
+  private static final String NUMBER_ARG = "{value, number, ::.#} kB";
+
+  @Test
+  void testIsIcuWithTypedArgument() {
+    assertTrue(IcuMessageEncoder.isIcu(NUMBER_ARG), "typed number arg is ICU");
+  }
+
+  @Test
+  void testIsIcuWithPluralHash() {
+    assertTrue(IcuMessageEncoder.isIcu(PLURAL_HASH), "plural with # is ICU");
+  }
+
+  @Test
+  void testIsIcuWithPluralText() {
+    assertTrue(IcuMessageEncoder.isIcu(PLURAL_TEXT), "plural with text is ICU");
+  }
+
+  @Test
+  void testIsIcuWithSimpleArgument() {
+    assertTrue(IcuMessageEncoder.isIcu("Hello {name}!"), "simple arg is ICU");
+  }
+
+  @Test
+  void testIsIcuFalseForPlainText() {
+    assertFalse(IcuMessageEncoder.isIcu("Hello World"), "plain text is not ICU");
+  }
+
+  @Test
+  void testIsIcuFalseForDatePattern() {
+    assertFalse(IcuMessageEncoder.isIcu("dd.MM.yyyy"), "no argument, not ICU");
+  }
+
+  @Test
+  void testIsIcuFalseForUnbalancedBraces() {
+    assertFalse(IcuMessageEncoder.isIcu("unclosed {brace"), "unparseable is not ICU");
+  }
+
+  @Test
+  void testEncodeXmlTypedArgument() {
+    assertEquals(
+        "<x>{value, number, ::.#}</x> kB",
+        IcuMessageEncoder.encodeXml(NUMBER_ARG),
+        "Unexpected ICU encoding");
+  }
+
+  @Test
+  void testEncodeXmlPluralWithHash() {
+    assertEquals(
+        "<x>{value_int, plural, one {#</x> Byte<x>} other {#</x> Bytes<x>}}</x>",
+        IcuMessageEncoder.encodeXml(PLURAL_HASH),
+        "Unexpected ICU encoding");
+  }
+
+  @Test
+  void testEncodeXmlPluralWithText() {
+    assertEquals(
+        "<x>{count, plural, one {</x>Kategorie<x>} other {</x>Kategorien<x>}}</x>",
+        IcuMessageEncoder.encodeXml(PLURAL_TEXT),
+        "Unexpected ICU encoding");
+  }
+
+  @Test
+  void testEncodeXmlSimpleArgument() {
+    assertEquals(
+        "Hello <x>{name}</x>!",
+        IcuMessageEncoder.encodeXml("Hello {name}!"),
+        "Unexpected ICU encoding");
+  }
+
+  @Test
+  void testRoundTripTypedArgument() {
+    assertEquals(
+        NUMBER_ARG,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(NUMBER_ARG)),
+        "Round trip must reconstruct the original ICU string");
+  }
+
+  @Test
+  void testRoundTripPluralWithHash() {
+    assertEquals(
+        PLURAL_HASH,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(PLURAL_HASH)),
+        "Round trip must reconstruct the original ICU string");
+  }
+
+  @Test
+  void testRoundTripPluralWithText() {
+    assertEquals(
+        PLURAL_TEXT,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(PLURAL_TEXT)),
+        "Round trip must reconstruct the original ICU string");
+  }
+
+  // --- Complex / multi-line ICU messages (regression coverage for folded-YAML scalars, nesting,
+  // select, selectordinal, offsets, and multiple arguments). Each asserts a lossless round trip:
+  // encodeXml -> decodeXml reconstructs the original string. ---
+
+  @Test
+  void testRoundTripMultilinePlural() {
+    // The real-world folded-YAML case: the plural message contains newlines inside the structure.
+    String msg = "{count, plural,\n    one   {Kategorie}\n    other {Kategorien}\n    }";
+    assertEquals(
+        msg,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg)),
+        "multi-line plural must round-trip");
+  }
+
+  @Test
+  void testMultilinePluralHasNoTagsAfterDecode() {
+    String msg = "{count, plural,\n    one   {Kategorie}\n    other {Kategorien}\n    }";
+    String decoded = Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg));
+    assertFalse(decoded.contains("<x>"), "decoded message must not contain <x> tags");
+  }
+
+  @Test
+  void testRoundTripSelect() {
+    String msg = "{gender, select, male {He replied} female {She replied} other {They replied}}";
+    assertEquals(
+        msg, Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg)), "select must round-trip");
+  }
+
+  @Test
+  void testRoundTripSelectOrdinal() {
+    String msg = "{place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} place";
+    assertEquals(
+        msg, Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg)), "selectordinal must round-trip");
+  }
+
+  @Test
+  void testRoundTripPluralWithOffset() {
+    String msg = "{count, plural, offset:1 =0 {nobody} one {someone} other {# people}}";
+    assertEquals(
+        msg,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg)),
+        "plural with offset/explicit value must round-trip");
+  }
+
+  @Test
+  void testRoundTripNestedSelectInPlural() {
+    String msg =
+        "{count, plural, one {{gender, select, male {his} female {her} other {their}} book}"
+            + " other {books}}";
+    assertEquals(
+        msg,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg)),
+        "nested select inside plural must round-trip");
+  }
+
+  @Test
+  void testRoundTripMultipleArgumentsWithSurroundingText() {
+    String msg = "You have {count, plural, one {# message} other {# messages}} from {sender}.";
+    assertEquals(
+        msg,
+        Decoder.decodeXml(IcuMessageEncoder.encodeXml(msg)),
+        "multiple args with surrounding text must round-trip");
+  }
+
+  @Test
+  void testNestedSelectInPluralTranslatesLiteralsOnly() {
+    // Simulate the provider: translate only the bare (non-<x>) literal segments, keep <x> verbatim,
+    // then decode. The ICU structure and nesting must survive; only literals change. The literal
+    // words are chosen to not be substrings of any ICU keyword/selector so the naive replace only
+    // touches literal text.
+    String msg =
+        "{count, plural, one {{gender, select, male {him} female {she} other {them}} chapter}"
+            + " other {chapters}}";
+    String encoded = IcuMessageEncoder.encodeXml(msg);
+    String translated =
+        encoded
+            .replace("him", "ihn")
+            .replace("she", "sie")
+            .replace("them", "sie")
+            .replace(" chapter", " Kapitel")
+            .replace("chapters", "Kapitel");
+    assertEquals(
+        "{count, plural, one {{gender, select, male {ihn} female {sie} other {sie}} Kapitel}"
+            + " other {Kapitel}}",
+        Decoder.decodeXml(translated),
+        "only literals translated, ICU structure intact");
+  }
+}


### PR DESCRIPTION
## Summary

Protects ICU MessageFormat structure when translating, so only the human-language literal text
is sent to the provider while argument names, `plural`/`select` keywords, selectors, braces, and
`#` are preserved.

The existing placeholder scanner only recognizes `{…}` when it wraps a bare identifier
(`{username}`). It mishandled real ICU MessageFormat strings — common in intl-icu translation
files:

- `{value, number, ::.#} kB` — not detected as a placeholder at all → sent raw and mangled.
- `{count, plural, one {Kategorie} other {Kategorien}}` — wrongly protected the words
  `Kategorie`/`Kategorien` (so they never translated) while translating the keywords
  `plural`/`one`/`other` (corrupting the format string).

## Approach

- Adds `com.ibm.icu:icu4j` and a new `IcuMessageEncoder` that parses the message with ICU4J's
  `MessagePattern`, then wraps every structural part in `<x>…</x>` and leaves only the literal
  text translatable. The literal-extraction walk mirrors ICU's own `MessageFormat` and recurses
  into every `plural`/`select` submessage.
- Reuses the existing `Format.XML` path: `Encoder.encodeXml` delegates to `IcuMessageEncoder`
  when the string parses as ICU (guarding legacy `${…}`), and `FormatDetector` now classifies ICU
  strings as XML. No changes to the `Format` enum, the translator pipeline, or provider dispatch —
  ICU strings flow through DeepL's existing `tag_handling=xml` / `ignore_tags=x`.
- `Decoder.decodeXml` now uses `Pattern.DOTALL` so a placeholder spanning **newlines** (e.g. a
  multi-line ICU string from a folded YAML `>-` scalar) is still unwrapped. Without this the
  `<x>` tags leaked into the output.

## Scope / limitations

- **DeepL only.** LibreTranslate uses a different, span-based placeholder mechanism (no
  `ignore_tags` equivalent) and is unchanged; ICU-on-LibreTranslate is not protected.
- **Apostrophes**: if a *translation* introduces an apostrophe inside a plural/select submessage,
  the reassembled ICU could misparse (ICU treats `'` as quoting). Not hit by typical data;
  documented as a future hardening.
- **HTML + ICU mix**: a string with both an HTML entity and ICU is classified HTML (checked
  first) and uses the span encoder. Pre-existing precedence.

## Test plan

- [x] `mvn clean verify` (tests + SpotBugs + PMD + Spotless)
- New `IcuMessageEncoderTest`: detection, exact encodings, and lossless round-trips
  (`decodeXml(encodeXml(s)) == s`) for typed args, plural (with `#`), multi-line/folded plural,
  `select`, `selectordinal`, `offset`, nested select-in-plural, and multiple args.
- Extended `FormatDetectorTest`, `EncoderTest`, `DecoderTest` (incl. the multi-line unwrap);
  all pre-existing encoder/decoder cases still pass unchanged.

## Notes

- icu4j adds ~13 MB to the `jar-with-dependencies` fat jar.
