### PR TITLE
feat: match exclude keys by full nested path

### DIFF
--- a/src/main/java/com/sitepark/translate/translator/TranslatableTextNodeCollector.java
+++ b/src/main/java/com/sitepark/translate/translator/TranslatableTextNodeCollector.java
@@ -31,30 +31,34 @@ public class TranslatableTextNodeCollector {
   public List<TranslatableTextNode> collect(List<JsonNode> jsonList) {
     List<TranslatableTextNode> translatableTextNodeList = new ArrayList<>();
     for (JsonNode json : jsonList) {
-      this.filterTextNodes(null, null, json, translatableTextNodeList::add);
+      this.filterTextNodes(null, null, null, json, translatableTextNodeList::add);
     }
     return translatableTextNodeList;
   }
 
   public List<TranslatableTextNode> collect(JsonNode json) {
     List<TranslatableTextNode> translatableTextNodeList = new ArrayList<>();
-    this.filterTextNodes(null, null, json, translatableTextNodeList::add);
+    this.filterTextNodes(null, null, null, json, translatableTextNodeList::add);
     return translatableTextNodeList;
   }
 
   private void filterTextNodes(
-      JsonNode parent, Object nodeKey, JsonNode node, Consumer<TranslatableTextNode> consumer) {
+      JsonNode parent,
+      Object nodeKey,
+      String parentPath,
+      JsonNode node,
+      Consumer<TranslatableTextNode> consumer) {
+    String path = this.appendPath(parentPath, nodeKey);
     if (node instanceof ObjectNode) {
       node.fields()
-          .forEachRemaining(e -> filterTextNodes(node, e.getKey(), e.getValue(), consumer));
+          .forEachRemaining(e -> filterTextNodes(node, e.getKey(), path, e.getValue(), consumer));
     } else if (node instanceof ArrayNode arrayNode) {
       Iterator<JsonNode> it = arrayNode.elements();
       for (int i = 0; it.hasNext(); i++) {
-        this.filterTextNodes(node, i, it.next(), consumer);
+        this.filterTextNodes(node, i, path, it.next(), consumer);
       }
     } else if (node instanceof TextNode) {
-      String absoluteKeys = this.getAbsoluteKey(nodeKey);
-      if (this.excludesNodes != null && this.excludesNodes.contains(absoluteKeys)) {
+      if (this.isExcluded(path, nodeKey)) {
         return;
       }
       TranslatableTextNode updatableTextNode =
@@ -63,13 +67,39 @@ public class TranslatableTextNodeCollector {
     }
   }
 
-  private String getAbsoluteKey(Object nodeKey) {
+  /**
+   * A leaf is excluded if the excludes file contains its full nested-path key (e.g. {@code
+   * <fileKey>.format.file_size.unit.ZB}) or, for backward compatibility, its leaf-only key (e.g.
+   * {@code <fileKey>.ZB}).
+   */
+  private boolean isExcluded(String path, Object nodeKey) {
+    if (this.excludesNodes == null) {
+      return false;
+    }
+    String fullPathKey = this.withFileKey(path);
+    String leafOnlyKey = this.withFileKey(nodeKey == null ? null : nodeKey.toString());
+    return this.excludesNodes.contains(fullPathKey) || this.excludesNodes.contains(leafOnlyKey);
+  }
+
+  /** Appends a node key to the accumulated within-file path (null-safe). */
+  private String appendPath(String parentPath, Object nodeKey) {
     if (nodeKey == null) {
+      return parentPath;
+    }
+    if (parentPath == null || parentPath.isEmpty()) {
+      return nodeKey.toString();
+    }
+    return parentPath + "." + nodeKey;
+  }
+
+  /** Prefixes a within-file path (or leaf key) with the file base key. */
+  private String withFileKey(String suffix) {
+    if (suffix == null) {
       return this.key;
     }
     if (this.key == null) {
-      return nodeKey.toString();
+      return suffix;
     }
-    return this.key + "." + nodeKey;
+    return this.key + "." + suffix;
   }
 }

--- a/src/main/java/com/sitepark/translate/translator/TranslatableTextNodeCollectorExcludes.java
+++ b/src/main/java/com/sitepark/translate/translator/TranslatableTextNodeCollectorExcludes.java
@@ -24,6 +24,11 @@ public final class TranslatableTextNodeCollectorExcludes {
     return new TranslatableTextNodeCollectorExcludes(excludes);
   }
 
+  /** Builds excludes from a set of keys (one key per entry), primarily for testing. */
+  public static TranslatableTextNodeCollectorExcludes of(Set<String> excludes) {
+    return new TranslatableTextNodeCollectorExcludes(new HashSet<>(excludes));
+  }
+
   public boolean contains(String key) {
     return this.excludes.contains(key);
   }

--- a/src/test/java/com/sitepark/translate/translator/TranslatableTextNodeCollectorTest.java
+++ b/src/test/java/com/sitepark/translate/translator/TranslatableTextNodeCollectorTest.java
@@ -90,4 +90,32 @@ class TranslatableTextNodeCollectorTest {
     assertFalse(sources.contains("drop"), "array element excluded by indexed full path");
     assertTrue(sources.contains("keep"), "other array element remains");
   }
+
+  @Test
+  void testNullBaseKeyUsesPathDirectly() throws IOException {
+    // collector built without a base key -> keys are the bare nested path (no file prefix)
+    JsonNode node = new YAMLMapper().readTree("format:\n  date: dd.MM.yyyy\n");
+    Set<String> sources =
+        new TranslatableTextNodeCollector()
+                .excludes(TranslatableTextNodeCollectorExcludes.of(Set.of("format.date")))
+                .collect(node)
+                .stream()
+                .map(TranslatableTextNode::getSourceText)
+                .collect(Collectors.toSet());
+    assertFalse(sources.contains("dd.MM.yyyy"), "excluded via null-base full path");
+  }
+
+  @Test
+  void testRootScalarExcludedByBaseKey() throws IOException {
+    // a document that is a bare scalar: the node has no key, so it is addressed by the base key
+    JsonNode node = new YAMLMapper().readTree("\"just a string\"\n");
+    Set<String> sources =
+        new TranslatableTextNodeCollector("root")
+                .excludes(TranslatableTextNodeCollectorExcludes.of(Set.of("root")))
+                .collect(node)
+                .stream()
+                .map(TranslatableTextNode::getSourceText)
+                .collect(Collectors.toSet());
+    assertTrue(sources.isEmpty(), "root scalar excluded by base key");
+  }
 }

--- a/src/test/java/com/sitepark/translate/translator/TranslatableTextNodeCollectorTest.java
+++ b/src/test/java/com/sitepark/translate/translator/TranslatableTextNodeCollectorTest.java
@@ -1,0 +1,93 @@
+package com.sitepark.translate.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+class TranslatableTextNodeCollectorTest {
+
+  private static final String YAML =
+      "format:\n"
+          + "  file_size:\n"
+          + "    unit:\n"
+          + "      ZB: zebi\n"
+          + "  date: dd.MM.yyyy\n"
+          + "map:\n"
+          + "  label: Karte\n"
+          + "list:\n"
+          + "  label: Liste\n"
+          + "tags:\n"
+          + "  - keep\n"
+          + "  - drop\n";
+
+  private Set<String> collectSources(Set<String> excludeKeys) throws IOException {
+    JsonNode node = new YAMLMapper().readTree(YAML);
+    TranslatableTextNodeCollector collector = new TranslatableTextNodeCollector("msg.de");
+    if (excludeKeys != null) {
+      collector.excludes(TranslatableTextNodeCollectorExcludes.of(excludeKeys));
+    }
+    List<TranslatableTextNode> nodes = collector.collect(node);
+    return nodes.stream().map(TranslatableTextNode::getSourceText).collect(Collectors.toSet());
+  }
+
+  @Test
+  void testNoExcludesCollectsEverything() throws Exception {
+    Set<String> sources = this.collectSources(null);
+    assertEquals(6, sources.size(), "all leaves collected");
+    assertTrue(sources.contains("zebi"), "ZB value present");
+  }
+
+  @Test
+  void testExcludeByFullNestedPath() throws Exception {
+    Set<String> sources = this.collectSources(Set.of("msg.de.format.file_size.unit.ZB"));
+    assertFalse(sources.contains("zebi"), "nested leaf excluded by full path");
+    assertEquals(5, sources.size(), "only one leaf removed");
+  }
+
+  @Test
+  void testExcludeByLeafOnlyKeyStillWorks() throws Exception {
+    // backward compatibility: the old leaf-only key must keep matching
+    Set<String> sources = this.collectSources(Set.of("msg.de.ZB"));
+    assertFalse(sources.contains("zebi"), "nested leaf excluded by leaf-only key");
+  }
+
+  @Test
+  void testFullPathIsPrecise() throws Exception {
+    // "label" appears twice (map.label, list.label); the full path targets only one
+    Set<String> sources = this.collectSources(Set.of("msg.de.map.label"));
+    assertFalse(sources.contains("Karte"), "map.label excluded");
+    assertTrue(sources.contains("Liste"), "list.label must remain");
+  }
+
+  @Test
+  void testLeafOnlyKeyMatchesAllSameNamedLeaves() throws Exception {
+    // preserved legacy behavior: a leaf-only key still matches every same-named leaf
+    Set<String> sources = this.collectSources(Set.of("msg.de.label"));
+    assertFalse(sources.contains("Karte"), "map.label excluded by leaf-only key");
+    assertFalse(sources.contains("Liste"), "list.label excluded by leaf-only key");
+  }
+
+  @Test
+  void testDepthOneKeyUnaffected() throws Exception {
+    // format.date is depth 2 here, but a top-level-style key resolves the same either way;
+    // verify the full path form works for the date pattern
+    Set<String> sources = this.collectSources(Set.of("msg.de.format.date"));
+    assertFalse(sources.contains("dd.MM.yyyy"), "format.date excluded by full path");
+  }
+
+  @Test
+  void testExcludeArrayElementByFullPath() throws Exception {
+    Set<String> sources = this.collectSources(Set.of("msg.de.tags.1"));
+    assertFalse(sources.contains("drop"), "array element excluded by indexed full path");
+    assertTrue(sources.contains("keep"), "other array element remains");
+  }
+}


### PR DESCRIPTION
## Summary

Makes `.excludes` keys match on the **full nested path** of a translatable node, not just its
immediate leaf key.

`TranslatableTextNodeCollector` only ever built `<fileKey>.<immediateLeafKey>` — it never
accumulated the nested object path. That works for the shallow "one file per namespace" layout of
the list translators (`TranslateJson`/`TranslateYaml`), where the filename carries the namespace,
but for a single deeply-nested file (`TranslateJsonFile`/`TranslateYamlFile`) a node like
`format.file_size.unit.ZB` collapsed to just `<fileKey>.ZB`. That's imprecise (a leaf-only key
matches every same-named leaf) and impossible to target unambiguously.

## Change

- The collector now threads an accumulated path through the recursion, so a leaf reports its full
  within-file path (e.g. `format.file_size.unit.ZB`).
- A leaf is excluded if the excludes set contains **either** the full-path key **or** the old
  leaf-only key.

## Backward compatibility

Strict superset of today's behavior — nothing that was excluded before stops being excluded:

- Existing `.excludes` files use leaf-only keys → still matched via the leaf-only check,
  identically to before (incl. their existing ambiguity where a leaf-only key matches all
  same-named leaves).
- New files may use precise full-path keys, e.g. `msg.de.map.label` to exclude only `map.label`
  and not `list.label`.
- Depth-1 keys are identical in both forms.

## Also

- Adds `TranslatableTextNodeCollectorExcludes.of(Set<String>)` for unit testing.

## Test plan

- [x] `mvn clean verify` (tests + SpotBugs + PMD + Spotless)
- New `TranslatableTextNodeCollectorTest`: exclude by full path, by leaf-only key (compat),
  full-path precision (targets one of two same-named leaves), leaf-only still matches all
  same-named leaves, and array-element exclusion by indexed path.
- Existing file-translator exclude tests (leaf-only keys) still pass unchanged.
